### PR TITLE
fix missing default_water_source.png

### DIFF
--- a/mobs/whale.lua
+++ b/mobs/whale.lua
@@ -59,4 +59,4 @@ mobs:register_mob("dmobs:whale", {
 })
 
 
-mobs:register_egg("dmobs:whale", "Whale", "default_water_source.png", 1)
+mobs:register_egg("dmobs:whale", "Whale", "default_water.png", 1)


### PR DESCRIPTION
replace water texture.

> ERROR[Main]: generateImage(): Could not load image "default_water_source.png" while building texture; Creating a dummy image

reported here: https://github.com/D00Med/dmobs/issues/23